### PR TITLE
Fix compilation error

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,6 @@
 lib_LTLIBRARIES = libirstlm.la
 
-AM_CXXFLAGS = -static -isystem/usr/include -W -Wall -ffor-scope -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES $(BOOST_CPPFLAGS) -DMYCODESIZE=3
+AM_CXXFLAGS = -static -Wall -ffor-scope -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES $(BOOST_CPPFLAGS) -DMYCODESIZE=3
 
 libirstlm_ladir = ${includedir}
 


### PR DESCRIPTION
--------------------
/bin/sh ../libtool  --tag=CXX   --mode=compile g++ -DHAVE_CONFIG_H -I. -I..   -DTRACE_LEVEL=1 -DMY_ASSERT_FLAG -DHAVE_CXX0 -std=c++0x -static -isystem/usr/include -W -Wall -ffor-scope -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES  -DMYCODESIZE=3 -g -O2 -MT dictionary.lo -MD -MP -MF .deps/dictionary.Tpo -c -o dictionary.lo dictionary.cpp
libtool: compile:  g++ -DHAVE_CONFIG_H -I. -I.. -DTRACE_LEVEL=1 -DMY_ASSERT_FLAG -DHAVE_CXX0 -std=c++0x -isystem/usr/include -W -Wall -ffor-scope -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -DMYCODESIZE=3 -g -O2 -MT dictionary.lo -MD -MP -MF .deps/dictionary.Tpo -c dictionary.cpp -o dictionary.o
In file included from /usr/include/c++/6.3.1/ext/string_conversions.h:41:0,
                 from /usr/include/c++/6.3.1/bits/basic_string.h:5402,
                 from /usr/include/c++/6.3.1/string:52,
                 from /usr/include/c++/6.3.1/bits/locale_classes.h:40,
                 from /usr/include/c++/6.3.1/bits/ios_base.h:41,
                 from /usr/include/c++/6.3.1/iomanip:40,
                 from dictionary.cpp:25:
/usr/include/c++/6.3.1/cstdlib:75:25: fatal error: stdlib.h: No such file or directory
 #include_next <stdlib.h>
--------------------