### PR TITLE
newer compiler do not the CPPFLAGS containing CXX options when compil…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -160,19 +160,19 @@ else
     AC_MSG_NOTICE([optimization disabled (default)])
 fi
 
-if test "x$enable_cxx0" != 'xno'
-then
-    AC_MSG_NOTICE([c++x0 dialect is enabled (default), compilation with "-DHAVE_CXX0 -std=c++0x "])
-    CPPFLAGS="$CPPFLAGS -DHAVE_CXX0 -std=c++0x";
-else
-    AC_MSG_NOTICE([c++x0 dialect is disabled, compilation without "-std=c++0x" and with "-UHAVE_CXX0"])
-    CPPFLAGS="$CPPFLAGS -UHAVE_CXX0";
-fi
-
 if test "x$with_zlib" != 'xno'
 then
   CPPFLAGS="$CPPFLAGS -I${with_zlib}/include"
   LDFLAGS="$LDFLAGS -L${with_zlib}/lib"
+fi
+
+if test "x$enable_cxx0" != 'xno'
+then
+    AC_MSG_NOTICE([c++x0 dialect is enabled (default), compilation with "-DHAVE_CXX0 -std=c++0x "])
+    CXXFLAGS="$CXXFLAGS -DHAVE_CXX0 -std=c++0x";
+else
+    AC_MSG_NOTICE([c++x0 dialect is disabled, compilation without "-std=c++0x" and with "-UHAVE_CXX0"])
+    CXXFLAGS="$CXXFLAGS -UHAVE_CXX0";
 fi
 
 LIBS="$LIBS -lz"


### PR DESCRIPTION
I've found this important for clang in MacOS, perhaps important somewhere else as well. Should not harm anyone.
```
/bin/sh ../libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I. -I..   -DTRACE_LEVEL=1 -DMY_ASSERT_FLAG -DHAVE_CXX0 -std=c++0x  -g -O2 -MT cmd.lo -MD -MP -MF .deps/cmd.Tpo -c -o cmd.lo cmd.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I.. -DTRACE_LEVEL=1 -DMY_ASSERT_FLAG -DHAVE_CXX0 -std=c++0x -g -O2 -MT cmd.lo -MD -MP -MF .deps/cmd.Tpo -c cmd.c  -fno-common -DPIC -o .libs/cmd.o
error: invalid argument '-std=c++0x' not allowed with 'C/ObjC'
```
