### PR TITLE
don't restrict permissions of scripts

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,5 +1,4 @@
 INSTALL(PROGRAMS
     add-start-end.sh build-lm-qsub.sh build-lm.sh build-sublm.pl goograms2ngrams.pl lm-stat.pl mdtsel.sh merge-sublm.pl ngram-split.pl rm-start-end.sh sort-lm.pl split-dict.pl split-ngt.sh wrapper 
     DESTINATION bin
-    PERMISSIONS OWNER_EXECUTE OWNER_READ OWNER_WRITE
     )


### PR DESCRIPTION
Before this pull request, the scripts (add-start-end.sh, build-lm-qsub.sh, build-lm.sh, build-sublm.pl, goograms2ngrams.pl, lm-stat.pl, mdtsel.sh, merge-sublm.pl, ngram-split.pl, rm-start-end.sh, sort-lm.pl, split-dict.pl, split-ngt.sh, wrapper) were installed with `rwx------` (0700) permission. This means users other than the owner were unable to use them.